### PR TITLE
fix: add missing column is_published and published_at column on posts table

### DIFF
--- a/database/migrations/2024_08_23_224808_add_missing_is_published__on_posts.php
+++ b/database/migrations/2024_08_23_224808_add_missing_is_published__on_posts.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->boolean('is_published')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('is_published');
+        });
+    }
+};

--- a/database/migrations/2024_08_23_224808_add_missing_is_published__on_posts.php
+++ b/database/migrations/2024_08_23_224808_add_missing_is_published__on_posts.php
@@ -12,7 +12,11 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->boolean('is_published')->default(false);
+            $table->after('slug', function (Blueprint $table) {
+                $table->boolean('is_published')->default(false);
+                $table->dateTime('published_at')
+                    ->nullable();
+            });
         });
     }
 
@@ -23,6 +27,7 @@ return new class extends Migration
     {
         Schema::table('posts', function (Blueprint $table) {
             $table->dropColumn('is_published');
+            $table->dropColumn('published_at');
         });
     }
 };


### PR DESCRIPTION
note:
- I added the missing migrations, but it does not mean it is the right way. A post just has a draft and published state?
