### PR TITLE
ci: add pipeline with pint and basic installation check

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,51 @@
+name: Quality
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@verbose
+      with:
+        php-version: '8.3'
+    
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.11.0'
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-build-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-build
+
+    - name: Copy .env
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+    
+    - name: Install Dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+    - name: Install Node Dependencies
+      run: npm install
+
+    - name: Generate Application key
+      run: php artisan key:generate
+
+    - name: Build assets
+      run: npm run build
+
+    - name: Checks Code styles
+      run: composer test:lint

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
             "@php artisan ide-helper:meta",
             "@php artisan ide-helper:models -N",
             "@php artisan ide-helper:eloquent"
+        ],
+        "test:lint": [
+            "./vendor/bin/pint --test"
         ]
     },
     "extra": {


### PR DESCRIPTION
- Pipeline for pint
- Check if basic installation is correct

Unfortunately the pipeline is only available in Ubuntu because of the action maintainer has only Ubuntu: https://github.com/shivammathur/setup-php

#8 to be merged first, else pipeline will fail