### PR TITLE
Fix: Sort Posts By Publish Date

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -16,7 +16,7 @@ class BlogController extends Controller
             ->where('is_published', true)
             ->orderBy('published_at', 'desc')
             ->paginate(10);
-            //->get();
+        //->get();
 
         return view('posts', compact('posts'));
     }

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -15,7 +15,8 @@ class BlogController extends Controller
         $posts = Post::with(['authors', 'categories'])
             ->where('is_published', true)
             ->orderBy('published_at', 'desc')
-            ->get();
+            ->paginate(10);
+            //->get();
 
         return view('posts', compact('posts'));
     }

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -40,8 +40,10 @@
             </div>
             @endforeach
         </div>
-
     </section>
+    <div class="mt-8 max-w-4xl mx-auto">
+        {{ $posts->links() }}
+    </div>
 @endsection
 
 @section('head')

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -25,7 +25,7 @@
                         </div>
                         <div>
                             <p class="text-xs uppercase font-semibold">By {{ $author->name }}</p>
-                            <p class="mt-0.5 text-xs font-light">{{ \Carbon\Carbon::parse($post->created_at)->format('d M Y') }}</p>
+                            <p class="mt-0.5 text-xs font-light">{{ \Carbon\Carbon::parse($post->published_at)->format('d M Y') }}</p>
                         </div>
                     </div>
                     @endforeach


### PR DESCRIPTION
It displayed created date, giving the impression the sorting was not functional. Fixed to show published_at field instead.