### PR TITLE
feat: clear cache only on recent events

### DIFF
--- a/app/Console/Commands/ClearCacheForEvents.php
+++ b/app/Console/Commands/ClearCacheForEvents.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use Illuminate\Console\Command;
+
+class ClearCacheForEvents extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'events:cache-clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will check events and clear cache';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $recentEvents = Event::query()
+            ->where('start_date', '<=', now()->addHours(24)->startOfDay())
+            ->where('start_date', '>=', value: now()->subHours(24)->startOfDay())
+            ->dumpRawSql()
+            ->exists();
+
+        if ($recentEvents) {
+            $this->call('responsecache:clear');
+            $this->info('Response cache cleared due to recent events.');
+
+            return;
+        }
+
+        $this->info('No upcoming or recent events. Cache not cleared.');
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();
+Schedule::command('events:cache-clear')->daily();


### PR DESCRIPTION
Have to add

```sh
* * * * * cd /path/to/project && php artisan schedule:run >> /dev/null 2>&1
```

Basically what it does:
- Check if there is any recent events, if it has just clear the cache.
- Clear cache for the 48hrs but only run at midnight.

Obviously, it is not necessary if we remove the caching feature.