### PR TITLE
Added date to admin panel

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -63,7 +63,10 @@ class EventResource extends Resource
             ->columns([
                 TextColumn::make('title')
                     ->label('Title'),
-                TextColumn::make('Type')
+                TextColumn::make('start_date')
+                    ->label('Date')
+                    ->sortable(),
+                TextColumn::make('type')
                     ->label('Event Type'),
             ])
             ->filters([


### PR DESCRIPTION
We have a year of meetups. This means duplicate titles (eg August Meetup).
So I can tell the difference, I added a date field in the table which is sortable.